### PR TITLE
fix(build): Remove invalid compose-compiler dependency

### DIFF
--- a/qrcodescanner/build.gradle.kts
+++ b/qrcodescanner/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.compose.compiler)
 
     // 日誌
     implementation(libs.timber)


### PR DESCRIPTION
The compose-compiler runtime is handled by the kotlin-compose plugin in Kotlin 2.0 and should not be an explicit dependency. Resolves: #3